### PR TITLE
kubectl: implement '--label' for 'create deployment'

### DIFF
--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -176,7 +176,7 @@ func MakeLabels(labels map[string]string) string {
 func ParseLabels(labelSpec interface{}) (map[string]string, error) {
 	labelString, isString := labelSpec.(string)
 	if !isString {
-		return nil, fmt.Errorf("expected string, found %v", labelSpec)
+		return nil, fmt.Errorf("expected Labels to be a string, found %#v", labelSpec)
 	}
 	if len(labelString) == 0 {
 		return nil, fmt.Errorf("no label spec passed")


### PR DESCRIPTION
NOTE: this PR is against my personal fork. This is a status update / request for design feedback.

```
kubectl: implement '--label' for 'create deployment'

Users of 'kubectl create deployment' can choose between two Generators.
These two Generators seem to be copy & paste jobs of each other. This
means that I had to make identical changes in each Generator to
implement support for the "labels" parameter. I would like to
consolidate these, but I don't know how to do that without breaking
compatibility.

This is a proof of concept and a general pattern of how I will bring
many other 'kubectl run' flags to 'create deployment'.

This change is (I believe) 100% backwards compatible and near as I can
tell from reading the code, idiomatic within the context of our system.
```

**Which issue this PR fixes**: progress towards kubernetes/kubectl#11

Feedback please :)
@pwittrock  @mengqiy 
